### PR TITLE
feat(browse): practical search & filters with pagination (online + local fallback)

### DIFF
--- a/lib/models/kanji.dart
+++ b/lib/models/kanji.dart
@@ -1,12 +1,13 @@
-// lib/models/kanji.dart
 import 'dart:convert';
 
 class Kanji {
   final int? id;
-  final String? deck; // N3/N4/N5（サーバ側で補完される場合あり）
-  final String kanji; // 例: 日
-  final String? meaning; // 意味（例: day; sun）
-  final String? reading; // ひとまとめの読みがある場合のみ
+  final String? deck; // N3/N4/N5 等。サーバー側で補完されることもある
+  final String kanji; // 本体
+  final String? meaning; // 単一意味（後方互換）
+  final List<String>? meanings; // 複数意味
+  final String? reading; // 単一読み（後方互換）
+  final List<String>? readings; // 複数読み
   final List<String>? kunyomi; // くんよみ
   final List<String>? onyomi; // おんよみ
   final String? visualHint; // 視覚ヒント
@@ -14,14 +15,18 @@ class Kanji {
   final List<String>? audioKunyomi;
   final List<String>? audioOnyomi;
   final String? example; // 例文
-  final String? translation; // 例文の翻訳など
+  final String? translation; // 例文の翻訳
+  final List<String>? tags;
+  final bool? isFavorite;
 
   const Kanji({
     this.id,
     this.deck,
     required this.kanji,
     this.meaning,
+    this.meanings,
     this.reading,
+    this.readings,
     this.kunyomi,
     this.onyomi,
     this.visualHint,
@@ -30,6 +35,8 @@ class Kanji {
     this.audioOnyomi,
     this.example,
     this.translation,
+    this.tags,
+    this.isFavorite,
   });
 
   /// JSON -> Kanji
@@ -37,7 +44,7 @@ class Kanji {
     List<String>? _optList(dynamic v) {
       if (v == null) return null;
       if (v is List) return v.map((e) => e.toString()).toList();
-      // カンマ区切りの文字列で来た場合の救済
+      // カンマ区切りの文字列で来た場合も吸収
       if (v is String) {
         final s = v.trim();
         if (s.isEmpty) return null;
@@ -46,14 +53,27 @@ class Kanji {
       return null;
     }
 
+    bool? _optBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is String) {
+        final lower = v.toLowerCase();
+        if (lower == 'true') return true;
+        if (lower == 'false') return false;
+      }
+      if (v is num) return v != 0;
+      return null;
+    }
+
     return Kanji(
       id: json['id'] is int
           ? json['id'] as int
           : (json['id'] is num ? (json['id'] as num).toInt() : null),
-      deck: json['deck']?.toString(),
+      deck: (json['deck'] ?? json['level'])?.toString(),
       kanji: json['kanji']?.toString() ?? '',
       meaning: json['meaning']?.toString(),
+      meanings: _optList(json['meanings']),
       reading: json['reading']?.toString(),
+      readings: _optList(json['readings']),
       kunyomi: _optList(json['kunyomi']),
       onyomi: _optList(json['onyomi']),
       visualHint: json['visualHint']?.toString() ?? json['hint']?.toString(),
@@ -62,6 +82,8 @@ class Kanji {
       audioOnyomi: _optList(json['audioOnyomi']),
       example: json['example']?.toString(),
       translation: json['translation']?.toString(),
+      tags: _optList(json['tags']),
+      isFavorite: _optBool(json['favorite']),
     );
   }
 
@@ -72,7 +94,9 @@ class Kanji {
       if (deck != null) 'deck': deck,
       'kanji': kanji,
       if (meaning != null) 'meaning': meaning,
+      if (meanings != null) 'meanings': meanings,
       if (reading != null) 'reading': reading,
+      if (readings != null) 'readings': readings,
       if (kunyomi != null) 'kunyomi': kunyomi,
       if (onyomi != null) 'onyomi': onyomi,
       if (visualHint != null) 'visualHint': visualHint,
@@ -81,6 +105,8 @@ class Kanji {
       if (audioOnyomi != null) 'audioOnyomi': audioOnyomi,
       if (example != null) 'example': example,
       if (translation != null) 'translation': translation,
+      if (tags != null) 'tags': tags,
+      if (isFavorite != null) 'favorite': isFavorite,
     };
   }
 
@@ -89,7 +115,9 @@ class Kanji {
     String? deck,
     String? kanji,
     String? meaning,
+    List<String>? meanings,
     String? reading,
+    List<String>? readings,
     List<String>? kunyomi,
     List<String>? onyomi,
     String? visualHint,
@@ -98,13 +126,17 @@ class Kanji {
     List<String>? audioOnyomi,
     String? example,
     String? translation,
+    List<String>? tags,
+    bool? isFavorite,
   }) {
     return Kanji(
       id: id ?? this.id,
       deck: deck ?? this.deck,
       kanji: kanji ?? this.kanji,
       meaning: meaning ?? this.meaning,
+      meanings: meanings ?? this.meanings,
       reading: reading ?? this.reading,
+      readings: readings ?? this.readings,
       kunyomi: kunyomi ?? this.kunyomi,
       onyomi: onyomi ?? this.onyomi,
       visualHint: visualHint ?? this.visualHint,
@@ -113,6 +145,8 @@ class Kanji {
       audioOnyomi: audioOnyomi ?? this.audioOnyomi,
       example: example ?? this.example,
       translation: translation ?? this.translation,
+      tags: tags ?? this.tags,
+      isFavorite: isFavorite ?? this.isFavorite,
     );
   }
 

--- a/lib/pages/browse_page.dart
+++ b/lib/pages/browse_page.dart
@@ -1,13 +1,14 @@
-// lib/pages/browse_page.dart
 import 'package:flutter/material.dart';
-import '../services/api_service.dart';
-import '../services/settings_service.dart';
-import '../services/selection_service.dart';
+
 import '../models/kanji.dart';
+import '../services/api_service.dart';
+import '../services/selection_service.dart';
+import '../services/settings_service.dart';
+import '../utils/debounce.dart';
 import 'quiz_page.dart';
 
 class BrowsePage extends StatefulWidget {
-  final String? initialDeck; // null の場合は設定から
+  final String? initialDeck;
   const BrowsePage({super.key, this.initialDeck});
 
   @override
@@ -15,14 +16,23 @@ class BrowsePage extends StatefulWidget {
 }
 
 class _BrowsePageState extends State<BrowsePage> {
+  final Debouncer _debouncer = Debouncer(milliseconds: 300);
+  final TextEditingController _searchCtrl = TextEditingController();
+  final TextEditingController _tagCtrl = TextEditingController();
+  final Set<String> _selected = <String>{};
+  final Map<String, Kanji> _knownKanji = {};
+
   bool _loading = true;
   List<String> _levels = [];
-  String _deck = ''; // 非null String
-  List<Kanji> _all = [];
-  final _searchCtrl = TextEditingController();
-
-  // ★ フィールド（getter ではなく通常フィールド）
-  final Set<String> _selected = <String>{};
+  String _level = 'All';
+  String _readingType = 'All';
+  bool _favoriteOnly = false;
+  String _query = '';
+  String _tag = '';
+  int _page = 0;
+  final int _size = 20;
+  int _total = 0;
+  List<Kanji> _items = [];
 
   @override
   void initState() {
@@ -33,6 +43,8 @@ class _BrowsePageState extends State<BrowsePage> {
   @override
   void dispose() {
     _searchCtrl.dispose();
+    _tagCtrl.dispose();
+    _debouncer.dispose();
     super.dispose();
   }
 
@@ -40,60 +52,98 @@ class _BrowsePageState extends State<BrowsePage> {
     setState(() => _loading = true);
     try {
       final levels = await ApiService.fetchLevels();
-      String deck =
-          widget.initialDeck ?? (await SettingsService.loadDeck() ?? '');
-      if (deck.isEmpty && levels.isNotEmpty) deck = levels.first;
-
-      List<Kanji> list = [];
-      if (deck.isNotEmpty) {
-        list = await ApiService.fetchKanjiByDeck(deck);
-      }
-
+      final stored = widget.initialDeck ?? await SettingsService.loadDeck();
+      final initial =
+          (stored != null && stored.isNotEmpty && levels.contains(stored))
+          ? stored
+          : (levels.isNotEmpty ? levels.first : 'All');
       setState(() {
         _levels = levels;
-        _deck = deck;
-        _all = list;
+        _level = initial;
+        _searchCtrl.text = _query;
+        _tagCtrl.text = _tag;
       });
+      await _runSearch(resetPage: true);
     } finally {
-      setState(() => _loading = false);
+      if (mounted) {
+        setState(() => _loading = false);
+      }
     }
   }
 
-  Future<void> _reloadDeck(String deck) async {
+  Future<void> _runSearch({bool resetPage = false}) async {
+    final nextPage = resetPage ? 0 : _page;
     setState(() {
-      _deck = deck;
+      if (resetPage) {
+        _page = 0;
+        _items = const [];
+        _total = 0;
+      }
       _loading = true;
-      _all = [];
-      _selected.clear();
     });
-    final list = await ApiService.fetchKanjiByDeck(deck);
-    setState(() {
-      _all = list;
-      _loading = false;
-    });
+    try {
+      final service = const ApiService();
+      final result = await service.searchKanji(
+        query: _query,
+        page: nextPage,
+        size: _size,
+        favoriteOnly: _favoriteOnly,
+        level: _level,
+        readingType: _readingType == 'All' ? null : _readingType,
+        tag: _tag.isEmpty ? null : _tag,
+      );
+      if (!mounted) return;
+      setState(() {
+        _items = result.items;
+        _total = result.total;
+        _page = result.page;
+        for (final k in result.items) {
+          _knownKanji[k.kanji] = k;
+        }
+        _loading = false;
+      });
+    } catch (err) {
+      if (!mounted) return;
+      setState(() {
+        _items = const [];
+        _total = 0;
+        _loading = false;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('検索に失敗しました: $err')));
+    }
   }
 
-  List<Kanji> get _filtered {
-    final q = _searchCtrl.text.trim();
-    if (q.isEmpty) return _all;
-    return _all.where((k) {
-      final m = k.meaning ?? '';
-      return k.kanji.contains(q) ||
-          m.contains(q) ||
-          (k.reading ?? '').contains(q);
-    }).toList();
+  int _maxPage() => _total == 0 ? 0 : ((_total - 1) ~/ _size);
+
+  void _nextPage() {
+    if (_page >= _maxPage()) return;
+    setState(() => _page += 1);
+    _runSearch();
+  }
+
+  void _prevPage() {
+    if (_page == 0) return;
+    setState(() => _page -= 1);
+    _runSearch();
   }
 
   Future<void> _saveCurrentSelection() async {
-    final ids = _selected.toList(); // 文字列IDをそのまま保存
+    if (_level == 'All') {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('レベルを選択してから保存してください')));
+      return;
+    }
+    final ids = _selected.toList();
     if (ids.isEmpty) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('選択がありません')));
       return;
     }
-    // _deck は non-null なので ?? は不要（dead_null_aware_expression 回避）
-    await SelectionService.saveSelection(deck: _deck, ids: ids, mode: null);
+    await SelectionService.saveSelection(deck: _level, ids: ids, mode: null);
     if (!mounted) return;
     ScaffoldMessenger.of(
       context,
@@ -106,17 +156,24 @@ class _BrowsePageState extends State<BrowsePage> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('保存された選択はありません')));
+      ).showSnackBar(const SnackBar(content: Text('保存された選択がありません')));
       return;
     }
-
-    // stored.deck が空なら現在の _deck を使う（?? は使わない）
-    final deck = stored.deck.isNotEmpty ? stored.deck : _deck;
-
+    final deck = stored.deck.isNotEmpty
+        ? stored.deck
+        : (_level != 'All'
+              ? _level
+              : (_levels.isNotEmpty ? _levels.first : ''));
+    if (deck.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('デッキを特定できませんでした')));
+      return;
+    }
     final all = await ApiService.fetchKanjiByDeck(deck);
     final by = {for (final k in all) k.kanji: k};
     final subset = stored.ids.map((id) => by[id]).whereType<Kanji>().toList();
-
     if (subset.isEmpty) {
       if (!mounted) return;
       ScaffoldMessenger.of(
@@ -124,7 +181,7 @@ class _BrowsePageState extends State<BrowsePage> {
       ).showSnackBar(const SnackBar(content: Text('選択カードが見つかりません')));
       return;
     }
-
+    if (!mounted) return;
     await Navigator.push(
       context,
       MaterialPageRoute(
@@ -135,24 +192,40 @@ class _BrowsePageState extends State<BrowsePage> {
 
   Future<void> _startFromCurrent({required bool srs}) async {
     if (_selected.isEmpty) return;
-    final by = {for (final k in _all) k.kanji: k};
-    final subset = _selected.map((id) => by[id]).whereType<Kanji>().toList();
+    if (_level == 'All') {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('レベルを選択してから開始してください')));
+      return;
+    }
+    final subset = _selected
+        .map((id) => _knownKanji[id])
+        .whereType<Kanji>()
+        .toList();
+    if (subset.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('選択カードの情報が見つかりません')));
+      return;
+    }
     await Navigator.push(
       context,
       MaterialPageRoute(
         builder: (_) =>
-            QuizPage(deck: _deck, srsMode: srs, presetCards: subset),
+            QuizPage(deck: _level, srsMode: srs, presetCards: subset),
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final totalPages = _maxPage() + 1;
+    final currentPageLabel = _total == 0 ? 0 : _page + 1;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('カード一覧（選択→保存/復元）'),
+        title: const Text('カード一覧（検索/保存）'),
         actions: [
-          // ★ ここから実際に _startFromSaved を参照（unused_element を解消）
           IconButton(
             icon: const Icon(Icons.save_alt),
             tooltip: '選択を保存',
@@ -168,70 +241,171 @@ class _BrowsePageState extends State<BrowsePage> {
             tooltip: '保存した選択でSRS',
             onPressed: () => _startFromSaved(srs: true),
           ),
-          // ★ ここまで
         ],
       ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : Column(
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+            child: Column(
               children: [
-                // デッキ切替 + 検索
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: DropdownButtonFormField<String>(
-                          value: _deck.isEmpty ? null : _deck,
-                          items: _levels
-                              .map(
-                                (e) =>
-                                    DropdownMenuItem(value: e, child: Text(e)),
-                              )
-                              .toList(),
-                          hint: const Text('デッキ'),
-                          onChanged: (v) {
-                            if (v != null) _reloadDeck(v);
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: _searchCtrl,
+                        decoration: InputDecoration(
+                          prefixIcon: const Icon(Icons.search),
+                          hintText: '漢字 / 意味 / 読み',
+                          isDense: true,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        onChanged: (value) {
+                          setState(() => _query = value);
+                          _debouncer.run(() => _runSearch(resetPage: true));
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextField(
+                        controller: _tagCtrl,
+                        decoration: InputDecoration(
+                          prefixIcon: const Icon(Icons.label),
+                          hintText: 'タグ / 部首',
+                          isDense: true,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        onChanged: (value) {
+                          setState(() => _tag = value);
+                          _debouncer.run(() => _runSearch(resetPage: true));
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        value: _level,
+                        items: ['All', ..._levels]
+                            .map(
+                              (e) => DropdownMenuItem(value: e, child: Text(e)),
+                            )
+                            .toList(),
+                        decoration: const InputDecoration(
+                          labelText: 'レベル',
+                          isDense: true,
+                          border: OutlineInputBorder(),
+                        ),
+                        onChanged: (value) {
+                          if (value == null) return;
+                          setState(() {
+                            _level = value;
+                            _selected.clear();
+                          });
+                          _runSearch(resetPage: true);
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        value: _readingType,
+                        items: const [
+                          DropdownMenuItem(
+                            value: 'All',
+                            child: Text('読み種別: すべて'),
+                          ),
+                          DropdownMenuItem(value: 'on', child: Text('音読み')),
+                          DropdownMenuItem(value: 'kun', child: Text('訓読み')),
+                        ],
+                        decoration: const InputDecoration(
+                          isDense: true,
+                          border: OutlineInputBorder(),
+                        ),
+                        onChanged: (value) {
+                          if (value == null) return;
+                          setState(() => _readingType = value);
+                          _runSearch(resetPage: true);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        const Text('お気に入りのみ'),
+                        Switch(
+                          value: _favoriteOnly,
+                          onChanged: (value) {
+                            setState(() => _favoriteOnly = value);
+                            _runSearch(resetPage: true);
                           },
                         ),
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: TextField(
-                          controller: _searchCtrl,
-                          decoration: InputDecoration(
-                            prefixIcon: const Icon(Icons.search),
-                            hintText: '漢字 / 意味 / 読み',
-                            isDense: true,
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                          ),
-                          onChanged: (_) => setState(() {}),
-                        ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
+                    Text('合計 $_total 件'),
+                  ],
                 ),
-                const Divider(height: 1),
-                Expanded(
-                  child: ListView.separated(
-                    itemCount: _filtered.length,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('Page $currentPageLabel / $totalPages'),
+                    Row(
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.chevron_left),
+                          onPressed: _loading || _page == 0 ? null : _prevPage,
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.chevron_right),
+                          onPressed: _loading || _page >= _maxPage()
+                              ? null
+                              : _nextPage,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : _items.isEmpty
+                ? const Center(child: Text('該当するカードがありません'))
+                : ListView.separated(
+                    itemCount: _items.length,
                     separatorBuilder: (_, __) => const Divider(height: 1),
-                    itemBuilder: (_, i) {
-                      final k = _filtered[i];
+                    itemBuilder: (_, index) {
+                      final k = _items[index];
                       final selected = _selected.contains(k.kanji);
                       return CheckboxListTile(
                         value: selected,
-                        onChanged: (v) {
-                          setState(() {
-                            if (v == true) {
-                              _selected.add(k.kanji);
-                            } else {
-                              _selected.remove(k.kanji);
-                            }
-                          });
-                        },
+                        onChanged: (_level == 'All')
+                            ? null
+                            : (v) {
+                                setState(() {
+                                  if (v == true) {
+                                    _selected.add(k.kanji);
+                                  } else {
+                                    _selected.remove(k.kanji);
+                                  }
+                                });
+                              },
                         title: Text('${k.kanji}  ${k.meaning ?? ''}'),
                         subtitle: Text(
                           '読み: ${(k.reading ?? '').isNotEmpty ? k.reading! : _readingStr(k)}',
@@ -240,48 +414,49 @@ class _BrowsePageState extends State<BrowsePage> {
                       );
                     },
                   ),
-                ),
-                // 下部アクション
-                SafeArea(
-                  child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: ElevatedButton.icon(
-                            onPressed: _selected.isEmpty
-                                ? null
-                                : () => _startFromCurrent(srs: false),
-                            icon: const Icon(Icons.quiz),
-                            label: const Text('選択でクイズ'),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: ElevatedButton.icon(
-                            onPressed: _selected.isEmpty
-                                ? null
-                                : () => _startFromCurrent(srs: true),
-                            icon: const Icon(Icons.schedule),
-                            label: const Text('選択でSRS'),
-                          ),
-                        ),
-                      ],
+          ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _selected.isEmpty
+                          ? null
+                          : () => _startFromCurrent(srs: false),
+                      icon: const Icon(Icons.quiz),
+                      label: const Text('選択でクイズ'),
                     ),
                   ),
-                ),
-              ],
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _selected.isEmpty
+                          ? null
+                          : () => _startFromCurrent(srs: true),
+                      icon: const Icon(Icons.schedule),
+                      label: const Text('選択でSRS'),
+                    ),
+                  ),
+                ],
+              ),
             ),
+          ),
+        ],
+      ),
     );
   }
 
   String _readingStr(Kanji k) {
     if ((k.reading ?? '').trim().isNotEmpty) return k.reading!.trim();
     final parts = <String>[];
-    if (k.onyomi != null && k.onyomi!.isNotEmpty)
+    if (k.onyomi != null && k.onyomi!.isNotEmpty) {
       parts.add(k.onyomi!.join('・'));
-    if (k.kunyomi != null && k.kunyomi!.isNotEmpty)
+    }
+    if (k.kunyomi != null && k.kunyomi!.isNotEmpty) {
       parts.add(k.kunyomi!.join('・'));
-    return parts.isEmpty ? '（読み未登録）' : parts.join(' / ');
+    }
+    return parts.isEmpty ? '読み未登録' : parts.join(' / ');
   }
 }

--- a/lib/services/tags_service.dart
+++ b/lib/services/tags_service.dart
@@ -35,6 +35,11 @@ class TagsService {
     return m[kanji] ?? const [];
   }
 
+  static Future<Map<String, List<String>>> loadAllTagsMap() async {
+    final source = await _loadAll();
+    return source.map((key, value) => MapEntry(key, List<String>.from(value)));
+  }
+
   static Future<void> addTag(String kanji, String tag) async {
     final t = tag.trim();
     if (t.isEmpty) return;

--- a/lib/utils/debounce.dart
+++ b/lib/utils/debounce.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+class Debouncer {
+  Debouncer({this.milliseconds = 300});
+
+  final int milliseconds;
+  Timer? _timer;
+
+  void run(void Function() action) {
+    _timer?.cancel();
+    _timer = Timer(Duration(milliseconds: milliseconds), action);
+  }
+
+  void dispose() => _timer?.cancel();
+}


### PR DESCRIPTION
- Debounced keyword search (300ms)
- Filters: favorite-only, level (All/N3/N4/N5), reading type (All/on/kun), tag
- Pagination (prev/next); shows current page & total pages
- Online via /api/kanji/search; fallback to local dataset on failure
- Keeps minimal CI (analyze/format/test) green
